### PR TITLE
Add minimal React/TS realtime transcription demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # S2T-playground
+
+This example shows how to implement a minimal React + TypeScript front‑end that
+streams microphone audio to OpenAI's Realtime API for GPT‑4o transcription.
+
+## Development
+
+1. Compile the TypeScript files:
+   ```bash
+   npx tsc
+   ```
+
+2. Start a local server and open `index.html` in your browser:
+   ```bash
+   python3 -m http.server 8000
+   ```
+   Then visit <http://localhost:8000>.
+
+The app uses browser APIs to capture audio and send it over a WebSocket to the
+Realtime API. Replace the WebSocket URL with your authenticated endpoint.
+

--- a/dist/App.js
+++ b/dist/App.js
@@ -1,0 +1,46 @@
+import React, { useState, useRef } from 'https://esm.sh/react@18';
+export default function App() {
+    const [transcript, setTranscript] = useState('');
+    const wsRef = useRef(null);
+    const recorderRef = useRef(null);
+    const startRecording = async () => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        const recorder = new MediaRecorder(stream);
+        const ws = new WebSocket('wss://api.openai.com/v1/realtime'); // placeholder
+        ws.onmessage = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                if (data.text) {
+                    setTranscript((prev) => prev + data.text);
+                }
+            }
+            catch (e) {
+                console.error('Failed to parse message', e);
+            }
+        };
+        ws.onopen = () => {
+            ws.send(JSON.stringify({
+                model: 'gpt-4o-transcribe',
+                language: 'ja',
+            }));
+            recorder.start(250);
+        };
+        recorder.ondataavailable = (e) => {
+            if (ws.readyState === WebSocket.OPEN) {
+                ws.send(e.data);
+            }
+        };
+        recorderRef.current = recorder;
+        wsRef.current = ws;
+    };
+    const stopRecording = () => {
+        var _a, _b;
+        (_a = recorderRef.current) === null || _a === void 0 ? void 0 : _a.stop();
+        (_b = wsRef.current) === null || _b === void 0 ? void 0 : _b.close();
+    };
+    return (React.createElement("div", null,
+        React.createElement("h1", null, "Realtime Transcription"),
+        React.createElement("button", { onClick: startRecording }, "Start"),
+        React.createElement("button", { onClick: stopRecording }, "Stop"),
+        React.createElement("pre", null, transcript)));
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,8 @@
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+import App from './App.js';
+document.addEventListener('DOMContentLoaded', () => {
+    const root = document.getElementById('root');
+    if (root) {
+        createRoot(root).render(React.createElement(App, null));
+    }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>Realtime Transcription</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./dist/index.js"></script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useRef } from 'https://esm.sh/react@18';
+
+export default function App() {
+  const [transcript, setTranscript] = useState('');
+  const wsRef = useRef(null);
+  const recorderRef = useRef(null);
+
+  const startRecording = async () => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const recorder = new MediaRecorder(stream);
+    const ws = new WebSocket('wss://api.openai.com/v1/realtime'); // placeholder
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.text) {
+          setTranscript((prev) => prev + data.text);
+        }
+      } catch (e) {
+        console.error('Failed to parse message', e);
+      }
+    };
+
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({
+          model: 'gpt-4o-transcribe',
+          language: 'ja',
+        })
+      );
+      recorder.start(250);
+    };
+
+    recorder.ondataavailable = (e) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(e.data);
+      }
+    };
+
+    recorderRef.current = recorder;
+    wsRef.current = ws;
+  };
+
+  const stopRecording = () => {
+    recorderRef.current?.stop();
+    wsRef.current?.close();
+  };
+
+  return (
+    <div>
+      <h1>Realtime Transcription</h1>
+      <button onClick={startRecording}>Start</button>
+      <button onClick={stopRecording}>Stop</button>
+      <pre>{transcript}</pre>
+    </div>
+  );
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module 'https://*';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+import App from './App.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.getElementById('root');
+  if (root) {
+    createRoot(root).render(<App />);
+  }
+});

--- a/src/react-stubs.d.ts
+++ b/src/react-stubs.d.ts
@@ -1,0 +1,10 @@
+declare module 'https://esm.sh/react@18' {
+  export const useState: any;
+  export const useRef: any;
+}
+
+declare module 'https://esm.sh/react-dom@18/client' {
+  export const createRoot: any;
+}
+
+declare const React: any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "ESNext",
+    "lib": ["DOM", "ES2017"],
+    "jsx": "react",
+    "outDir": "dist",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add React+TS source files for a simple realtime transcription frontend
- configure TypeScript compiler and stub React modules
- provide example HTML and update README with build instructions

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_684118474694832ebc14129c234649a7